### PR TITLE
Create account if certs_dir is not present

### DIFF
--- a/muacme
+++ b/muacme
@@ -229,6 +229,11 @@ issue_cert() {
 }
 
 issue() {
+	# first run, create a new account
+	if [ ! -d "$certs_dir" ]; then
+		uacme -v -c "$certs_dir" new
+	fi
+
 	if [ "$_from_file" = yes ]; then
 		while read args; do
 			case "$args" in '#'* | '') continue;; esac


### PR DESCRIPTION
closes #1 

I am not an ACME expert, so this may be incorrect. But it seems reasonable to initialize an account on first run to me.